### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-api-list.yaml
+++ b/.github/workflows/update-api-list.yaml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   update-api-list:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/google-cloud-node/security/code-scanning/13](https://github.com/Dargon789/google-cloud-node/security/code-scanning/13)

In general, the fix is to add an explicit `permissions:` block to the workflow or to the specific job, granting only the scopes required for the job’s operations. This constrains the `GITHUB_TOKEN` to the minimal privileges needed and documents those needs.

For this specific workflow, the `update-api-list` job needs to be able to create/update branches and open pull requests via `googleapis/code-suggester@v5`. That requires write permission to repository contents and pull requests. The earlier steps (checkout, setup-node, `npm install`, `npm run generate`) only need read access to repository contents (and whatever the custom script does with `GITHUB_TOKEN`, which is typically repo-level). A minimal and functional permission set at the job level is therefore:

```yaml
permissions:
  contents: write
  pull-requests: write
```

You should add this block under `update-api-list:` and above `runs-on:` in `.github/workflows/update-api-list.yaml`. No additional imports or methods are required; this is purely a YAML configuration change and does not alter the functional behavior of the job, other than constraining token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add explicit write permissions for contents and pull requests to the update-api-list GitHub Actions job to satisfy code scanning requirements.